### PR TITLE
add an `include_str!` example

### DIFF
--- a/src/string.rs
+++ b/src/string.rs
@@ -237,7 +237,7 @@ impl<const N: usize> LoadedString<N> {
 		match res {
 			Ok(array) => {
 				let array = *array;
-				{
+				unsafe {
 					// SAFETY: the caller ensures that the bytes are valid
 					// UTF-8
 					Some(Self::from_array(array))
@@ -405,7 +405,7 @@ impl<const N: usize> PmString<N> {
 		match res {
 			Ok(array) => {
 				let array = *array;
-				{
+				unsafe {
 					// SAFETY: the caller ensures that this value is in progmem
 					// and the bytes are valid UTF-8
 					Some(Self::from_array(array))
@@ -433,7 +433,7 @@ impl<const N: usize> PmString<N> {
 		};
 		*/
 
-		let pm = {
+		let pm = unsafe {
 			// SAFETY: the caller ensures that this value is in progmem
 			ProgMem::new(array)
 		};

--- a/src/string.rs
+++ b/src/string.rs
@@ -95,6 +95,8 @@
 //!     // A simple Unicode string in progmem, internally stored as fix-sized
 //!     // byte array, i.e. a `PmString<18>`.
 //!     static progmem string TEXT = "Hello 大賢者";
+//!     // text too large to fit in the RAM of a microcontroller
+//!     static progmem string LOVECRAFT = include_str!("../examples/test_text.txt");
 //! }
 //!
 //! // You can load it all at once (like a `ProgMem`)
@@ -235,7 +237,7 @@ impl<const N: usize> LoadedString<N> {
 		match res {
 			Ok(array) => {
 				let array = *array;
-				unsafe {
+				{
 					// SAFETY: the caller ensures that the bytes are valid
 					// UTF-8
 					Some(Self::from_array(array))
@@ -403,7 +405,7 @@ impl<const N: usize> PmString<N> {
 		match res {
 			Ok(array) => {
 				let array = *array;
-				unsafe {
+				{
 					// SAFETY: the caller ensures that this value is in progmem
 					// and the bytes are valid UTF-8
 					Some(Self::from_array(array))
@@ -431,7 +433,7 @@ impl<const N: usize> PmString<N> {
 		};
 		*/
 
-		let pm = unsafe {
+		let pm = {
 			// SAFETY: the caller ensures that this value is in progmem
 			ProgMem::new(array)
 		};

--- a/src/string/validations.rs
+++ b/src/string/validations.rs
@@ -45,14 +45,14 @@ pub(super) unsafe fn next_code_point<I: Iterator<Item = u8>>(bytes: &mut I) -> O
 	let init = utf8_first_byte(x, 2);
 	// SAFETY: `bytes` produces an UTF-8-like string,
 	// so the iterator must produce a value here.
-	let y = unsafe { bytes.next().unwrap() };
+	let y = { bytes.next().unwrap() };
 	let mut ch = utf8_acc_cont_byte(init, y);
 	if x >= 0xE0 {
 		// [[x y z] w] case
 		// 5th bit in 0xE0 .. 0xEF is always clear, so `init` is still valid
 		// SAFETY: `bytes` produces an UTF-8-like string,
 		// so the iterator must produce a value here.
-		let z = unsafe { bytes.next().unwrap() };
+		let z = { bytes.next().unwrap() };
 		let y_z = utf8_acc_cont_byte((y & CONT_MASK) as u32, z);
 		ch = init << 12 | y_z;
 		if x >= 0xF0 {
@@ -60,7 +60,7 @@ pub(super) unsafe fn next_code_point<I: Iterator<Item = u8>>(bytes: &mut I) -> O
 			// use only the lower 3 bits of `init`
 			// SAFETY: `bytes` produces an UTF-8-like string,
 			// so the iterator must produce a value here.
-			let w = unsafe { bytes.next().unwrap() };
+			let w = { bytes.next().unwrap() };
 			ch = (init & 7) << 18 | utf8_acc_cont_byte(y_z, w);
 		}
 	}

--- a/src/string/validations.rs
+++ b/src/string/validations.rs
@@ -45,14 +45,14 @@ pub(super) unsafe fn next_code_point<I: Iterator<Item = u8>>(bytes: &mut I) -> O
 	let init = utf8_first_byte(x, 2);
 	// SAFETY: `bytes` produces an UTF-8-like string,
 	// so the iterator must produce a value here.
-	let y = { bytes.next().unwrap() };
+	let y = unsafe { bytes.next().unwrap() };
 	let mut ch = utf8_acc_cont_byte(init, y);
 	if x >= 0xE0 {
 		// [[x y z] w] case
 		// 5th bit in 0xE0 .. 0xEF is always clear, so `init` is still valid
 		// SAFETY: `bytes` produces an UTF-8-like string,
 		// so the iterator must produce a value here.
-		let z = { bytes.next().unwrap() };
+		let z = unsafe { bytes.next().unwrap() };
 		let y_z = utf8_acc_cont_byte((y & CONT_MASK) as u32, z);
 		ch = init << 12 | y_z;
 		if x >= 0xF0 {
@@ -60,7 +60,7 @@ pub(super) unsafe fn next_code_point<I: Iterator<Item = u8>>(bytes: &mut I) -> O
 			// use only the lower 3 bits of `init`
 			// SAFETY: `bytes` produces an UTF-8-like string,
 			// so the iterator must produce a value here.
-			let w = { bytes.next().unwrap() };
+			let w = unsafe { bytes.next().unwrap() };
 			ch = (init & 7) << 18 | utf8_acc_cont_byte(y_z, w);
 		}
 	}


### PR DESCRIPTION
I added the `include_str!` example we were talking about.  I also removed some `unsafe` keywords that the compiler said were unnecessary.  I know it has demanded the unsafe keyword in other instances of an unsafe function body, but I don't know all the subtleties.