### PR TITLE
Only import `core::arch::asm` when targeting AVR

### DIFF
--- a/src/raw.rs
+++ b/src/raw.rs
@@ -16,6 +16,7 @@
 //! memory domain via the function of this module.
 
 
+#[cfg(all(target_arch = "avr", not(doc)))]
 use core::arch::asm;
 use core::mem::size_of;
 use core::mem::MaybeUninit;


### PR DESCRIPTION
This gets rid of the compile-time warning about the unused import.