### PR TITLE
Impl unsized

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,10 @@ dev = []
 [dependencies]
 cfg-if = "1.0"
 
+[dependencies.derivative]
+version = "2.2.0"
+features = [ "use_core" ]
+
 [dependencies.ufmt]
 version = "0.1.0"
 optional = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,9 @@ default = ["lpm-asm-loop", "ufmt"]
 lpm-asm-loop = []
 # Enables some tweak to ease debugging, should not be use in production
 dev = []
+# Enables unsize utilities, such as wrapper coercing.
+# However, this requires additional nightly Rust features, which might be unstable.
+unsize = []
 
 [dependencies]
 cfg-if = "1.0"

--- a/examples/uno-slices.rs
+++ b/examples/uno-slices.rs
@@ -1,6 +1,6 @@
 //
-// This file provides a example on how to use array statics on an
-// Arduino Uno.
+// This file provides a example on how to work with slice in progmem (sort of)
+// on an Arduino Uno.
 //
 
 
@@ -14,13 +14,17 @@ use avr_progmem::wrapper::ProgMem;
 #[cfg(target_arch = "avr")]
 use panic_halt as _; // halting panic implementation for AVR
 
-
+// First, there are no slices in progmem. All data must be statically size,
+// such as an array:
 progmem! {
 	// Just one array of size 3
 	static progmem<const ARRAY_A_LEN: usize> ARRAY_A: [u8; ARRAY_A_LEN] = [1,2,3];
 
 	// Another array of size 5
 	static progmem<const ARRAY_B_LEN: usize> ARRAY_B: [u8; ARRAY_B_LEN] = [1,2,3,4,5];
+
+	// Yet another array
+	static progmem<const ARRAY_C_LEN: usize> ARRAY_C: [u8; ARRAY_C_LEN] = [42];
 }
 
 // Include a fancy printer supporting Arduino Uno's USB-Serial output as well
@@ -30,6 +34,71 @@ use printer::Printer;
 
 #[cfg_attr(target_arch = "avr", arduino_hal::entry)]
 fn main() -> ! {
+	// Setup the output
+	let mut printer = setup();
+
+	//
+	// Working with slices.
+	//
+	// So, we actually only have statically sized arrays in progmem. However,
+	// sometimes slices are nicer to work with, for instance if you want to put
+	// them into a list or something, e.g. to iterate over them.
+	//
+	// There are basically to way to accomplish this, first just load those
+	// arrays into RAM and coerce the standard Rust arrays into standard Rust
+	// slices as usual. The drawback is the potential high RAM usage.
+	//
+	// In order to have the benefits of slices while the data is still in
+	// progmem, we can also just coerce the ProgMems of arrays into ProgMems of
+	// slices, just like that:
+
+	let a_slice: ProgMem<[u8]> = ARRAY_A;
+	let b_slice: ProgMem<[u8]> = ARRAY_B;
+	let c_slice: ProgMem<[u8]> = ARRAY_C;
+
+	// Now they have the same type, and we can put them into a list.
+	let list_of_slices = [a_slice, b_slice, c_slice];
+
+	// And for instance iterate through that list.
+	for (i, slice) in list_of_slices.iter().enumerate() {
+		// Here `slice` is a `ProgMem<[u8]>`, which has (among others) a `len` and a
+		// `load_at` method.
+
+		ufmt::uwriteln!(
+			&mut printer,
+			"Element #{}, size: {}, first element: {}\r",
+			i,
+			slice.len(),
+			slice.load_at(0)
+		)
+		.unwrap();
+
+		// We can also use a progmem-iterator that gives a ProgMem wrapper for
+		// each element of that slice (without yet loading any of them).
+		for elem_wrapper in slice.wrapper_iter() {
+			// Fun fact, if that element happened to be another array, we would
+			// also iterate its elements without loading it yet.
+			// That allows to iterate multi-dimensional arrays and only ever
+			// loading a single element into RAM.
+
+			// Only load a single element at a time
+			let e = elem_wrapper.load();
+			ufmt::uwrite!(&mut printer, "{}, ", e).unwrap();
+		}
+		printer.println("");
+	}
+
+	// "end" the program
+	finish(printer)
+}
+
+//
+// Following are just some auxiliary functions to setup and finish up the Arduino
+//
+
+
+// Setup the serial UART as output at 9600 baud and print a "Hello from Arduino"
+fn setup() -> Printer {
 	let mut printer = {
 		#[cfg(target_arch = "avr")]
 		{
@@ -54,36 +123,12 @@ fn main() -> ! {
 	printer.println("--------------------------");
 	printer.println("");
 
-	//
-	// Coercing arrays into slices
-	//
+	// return the printer
+	printer
+}
 
-	// Assume that we want to put those to arrays into a vec (or just another
-	// array), but the problem is that since the have difference size, they have
-	// different types. One way to get rid of the static size, is to convert
-	// them dynamically sized slices, like this:
-
-	let a: ProgMem<[u8]> = ARRAY_A;
-	let b: ProgMem<[u8]> = ARRAY_B;
-
-	// Now they have the same type, and we can put them into a collection.
-
-	let collection = [a, b];
-
-	// Iterate through the collection
-	for (i, arr) in collection.iter().enumerate() {
-		ufmt::uwriteln!(&mut printer, "Element #{}, size: {}\r", i, arr.len()).unwrap();
-
-		// Iterate through the slice
-		for i in 0..arr.len() {
-			// Only load a single byte at a time
-			let e = arr.load_at(i);
-			ufmt::uwrite!(&mut printer, "{}, ", e).unwrap();
-		}
-		printer.println("");
-	}
-
-
+// Print a "DONE" and exit (or go into an infinite loop).
+fn finish(mut printer: Printer) -> ! {
 	// Print some final lines
 	printer.println("");
 	printer.println("--------------------------");

--- a/examples/uno-slices.rs
+++ b/examples/uno-slices.rs
@@ -1,0 +1,104 @@
+//
+// This file provides a example on how to use array statics on an
+// Arduino Uno.
+//
+
+
+// Define no_std only for AVR
+#![cfg_attr(target_arch = "avr", no_std)]
+#![cfg_attr(target_arch = "avr", no_main)]
+
+
+use avr_progmem::progmem; // The macro
+use avr_progmem::wrapper::ProgMem;
+#[cfg(target_arch = "avr")]
+use panic_halt as _; // halting panic implementation for AVR
+
+
+progmem! {
+	// Just one array of size 3
+	static progmem<const ARRAY_A_LEN: usize> ARRAY_A: [u8; ARRAY_A_LEN] = [1,2,3];
+
+	// Another array of size 5
+	static progmem<const ARRAY_B_LEN: usize> ARRAY_B: [u8; ARRAY_B_LEN] = [1,2,3,4,5];
+}
+
+// Include a fancy printer supporting Arduino Uno's USB-Serial output as well
+// as stdout on non-AVR targets.
+mod printer;
+use printer::Printer;
+
+#[cfg_attr(target_arch = "avr", arduino_hal::entry)]
+fn main() -> ! {
+	let mut printer = {
+		#[cfg(target_arch = "avr")]
+		{
+			// Initialize the USB-Serial output on the Arduino Uno
+
+			let dp = arduino_hal::Peripherals::take().unwrap();
+			let pins = arduino_hal::pins!(dp);
+			let serial = arduino_hal::default_serial!(dp, pins, 9600);
+
+			Printer(serial)
+		}
+		#[cfg(not(target_arch = "avr"))]
+		{
+			// Just use stdout for non-AVR targets
+			Printer
+		}
+	};
+
+	// Print some introduction text
+	printer.println("Hello from Arduino!");
+	printer.println("");
+	printer.println("--------------------------");
+	printer.println("");
+
+	//
+	// Coercing arrays into slices
+	//
+
+	// Assume that we want to put those to arrays into a vec (or just another
+	// array), but the problem is that since the have difference size, they have
+	// different types. One way to get rid of the static size, is to convert
+	// them dynamically sized slices, like this:
+
+	let a: ProgMem<[u8]> = ARRAY_A;
+	let b: ProgMem<[u8]> = ARRAY_B;
+
+	// Now they have the same type, and we can put them into a collection.
+
+	let collection = [a, b];
+
+	// Iterate through the collection
+	for (i, arr) in collection.iter().enumerate() {
+		ufmt::uwriteln!(&mut printer, "Element #{}, size: {}\r", i, arr.len()).unwrap();
+
+		// Iterate through the slice
+		for i in 0..arr.len() {
+			// Only load a single byte at a time
+			let e = arr.load_at(i);
+			ufmt::uwrite!(&mut printer, "{}, ", e).unwrap();
+		}
+		printer.println("");
+	}
+
+
+	// Print some final lines
+	printer.println("");
+	printer.println("--------------------------");
+	printer.println("");
+	printer.println("DONE");
+
+	// It is very convenient to just exit on non-AVR platforms, otherwise users
+	// might get the impression that the program hangs, whereas it already
+	// succeeded.
+	#[cfg(not(target_arch = "avr"))]
+	std::process::exit(0);
+
+	// Otherwise, that is on AVR, just go into an infinite loop, because on AVR
+	// we just can't exit!
+	loop {
+		// Done, just do nothing
+	}
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -107,7 +107,7 @@
 //! use core::ptr::addr_of;
 //!
 //! // This `static` must never be directly dereferenced/accessed!
-//! // So a `let data: u8 = P_BYTE;` is **undefined behavior**!!!
+//! // So a `let data: u8 = P_BYTE;` ⚠️ is **undefined behavior**!!!
 //! /// Static byte stored in progmem!
 //! #[link_section = ".progmem.data"]
 //! static P_BYTE: u8 = b'A';

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,10 +9,10 @@
 #![feature(slice_ptr_len)]
 //
 // Allow to implement `CoerceUnsized` on `ProgMem`
-#![feature(coerce_unsized)]
+#![cfg_attr(feature = "unsize", feature(coerce_unsized))]
 //
 // Needed for implementing `CoerceUnsized` on `ProgMem`
-#![feature(unsize)]
+#![cfg_attr(feature = "unsize", feature(unsize))]
 //
 // Allows to document required crate features on items
 #![cfg_attr(doc, feature(doc_auto_cfg))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,18 @@
 // As of now (mid 2022), inline assembly for AVR is still unstable.
 #![feature(asm_experimental_arch)]
 //
+// We to access the length of a slice pointer (for unsized `ProgMem`s)
+#![feature(slice_ptr_len)]
+//
+// We to access the address of elements of slice pointers (for unsized `ProgMem`s)
+#![feature(slice_ptr_get)]
+//
+// Allow to implement `CoerceUnsized` on `ProgMem`
+#![feature(coerce_unsized)]
+//
+// Needed for implementing `CoerceUnsized` on `ProgMem`
+#![feature(unsize)]
+//
 // Allows to document required crate features on items
 #![cfg_attr(doc, feature(doc_auto_cfg))]
 //

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,9 +8,6 @@
 // We to access the length of a slice pointer (for unsized `ProgMem`s)
 #![feature(slice_ptr_len)]
 //
-// We to access the address of elements of slice pointers (for unsized `ProgMem`s)
-#![feature(slice_ptr_get)]
-//
 // Allow to implement `CoerceUnsized` on `ProgMem`
 #![feature(coerce_unsized)]
 //

--- a/src/string.rs
+++ b/src/string.rs
@@ -375,7 +375,16 @@ impl<const N: usize> ufmt::uDisplay for LoadedString<N> {
 /// assert_eq!("dai 大賢者 kenja", &*loaded)
 /// ```
 ///
-#[non_exhaustive] // SAFETY: this struct must not be publicly constructible
+//
+//
+// SAFETY: this struct must not be publicly constructible
+#[non_exhaustive]
+//
+// Its just a pointer type, thus copy, clone & debug are fine (none of them
+// will access the progmem, that's what `Display` is for).
+#[derive(Copy, Clone, Debug)]
+// Also impl `uDebug` if enabled.
+#[cfg_attr(feature = "ufmt", derive(ufmt::derive::uDebug))]
 pub struct PmString<const N: usize> {
 	/// The inner UTF-8 string as byte array in progmem.
 	///

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -188,8 +188,22 @@ impl<T, const N: usize> ProgMem<[T; N]> {
 			target: element_ptr,
 		}
 	}
+
+	/// Iterate over all elements as wrappers.
+	///
+	/// Returns an iterator, which yields each element as a `ProgMem<T>`,
+	/// which can be subsequently loaded.
+	pub fn wrapper_iter(&self) -> PmWrapperIter<T, N> {
+		PmWrapperIter::new(self)
+	}
+
+	/// Returns the length of the array (i.e. `N`)
+	pub fn len(&self) -> usize {
+		N
+	}
 }
 
+/// Loading elements of an array in progmem.
 impl<T: Copy, const N: usize> ProgMem<[T; N]> {
 	/// Load a single element from the inner array.
 	///
@@ -286,15 +300,6 @@ impl<T: Copy, const N: usize> ProgMem<[T; N]> {
 	///
 	pub fn iter(&self) -> PmIter<T, N> {
 		PmIter::new(self)
-	}
-
-	pub fn wrapper_iter(&self) -> PmWrapperIter<T, N> {
-		PmWrapperIter::new(self)
-	}
-
-	/// Returns the length of the array (i.e. `N`)
-	pub fn len(&self) -> usize {
-		N
 	}
 }
 

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -352,13 +352,16 @@ impl<T> ProgMem<[T]> {
 		// SAFETY: check that `idx` is in bounds
 		assert!(idx < self.target.len(), "Given index is out of bounds");
 
+		let first_element_ptr: *const T = self.target.cast();
+
+		// Get a point to the selected element
+		let element_ptr = first_element_ptr.wrapping_add(idx);
+
 		// This sound, because `self.target` is in program domain and we checked
 		// above that `idx` is in bound, thus that element pointer is also
 		// valid and pointing into the program domain.
 		ProgMem {
-			// The `get_unchecked` is sound, because we checked above that `idx`
-			// is in bound.
-			target: unsafe { self.target.get_unchecked(idx) },
+			target: element_ptr,
 		}
 	}
 


### PR DESCRIPTION
This PR lifts the `Sized` constraint of `ProgMem`, adds methods for `ProgMem<[T]>` (a progmem slice), and add a method for coercing a progmem array to a progmem slice, allowing to abstract over differently sized arrays, while they are still in progmem. Also adds a new crate feature "unsize" that allows to directly coerce `ProgMem<[T;N]>` to `ProgMem<[T]>` (without that special method), tho it requires additional nightly Rust features, therefore it is behind that crate feature.

Fixes #8 